### PR TITLE
Log the execution time of methods in the service or repository layers #4

### DIFF
--- a/src/main/java/io/github/jhipster/sample/aop/LoggingAspect.java
+++ b/src/main/java/io/github/jhipster/sample/aop/LoggingAspect.java
@@ -1,0 +1,74 @@
+package io.github.jhipster.sample.aop;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StopWatch;
+
+/**
+ * Aspect for logging execution time of methods in service and repository layers.
+ * This helps identify performance bottlenecks in the application.
+ */
+@Aspect
+@Component
+public class LoggingAspect {
+
+    /**
+     * Pointcut that matches all Spring services.
+     */
+    @Pointcut("within(@org.springframework.stereotype.Service *)")
+    public void springServicePointcut() {
+        // Method is empty as this is just a pointcut declaration
+    }
+
+    /**
+     * Pointcut that matches all Spring repositories.
+     */
+    @Pointcut("within(@org.springframework.stereotype.Repository *)")
+    public void springRepositoryPointcut() {
+        // Method is empty as this is just a pointcut declaration
+    }
+
+    /**
+     * Pointcut that matches all Spring components with Service or Repository annotations.
+     */
+    @Pointcut("springServicePointcut() || springRepositoryPointcut()")
+    public void serviceOrRepositoryPointcut() {
+        // Method is empty as this is just a pointcut declaration
+    }
+
+    /**
+     * Advice that logs when a method is entered and exited, along with execution time.
+     *
+     * @param joinPoint join point for advice
+     * @return result
+     * @throws Throwable throws IllegalArgumentException
+     */
+    @Around("serviceOrRepositoryPointcut()")
+    public Object logExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+        Logger log = LoggerFactory.getLogger(joinPoint.getSignature().getDeclaringTypeName());
+
+        if (!log.isDebugEnabled()) {
+            return joinPoint.proceed();
+        }
+
+        MethodSignature methodSignature = (MethodSignature) joinPoint.getSignature();
+        String className = methodSignature.getDeclaringType().getSimpleName();
+        String methodName = methodSignature.getName();
+
+        final StopWatch stopWatch = new StopWatch();
+
+        stopWatch.start();
+        try {
+            return joinPoint.proceed();
+        } finally {
+            stopWatch.stop();
+            log.debug("Execution time of {}.{}(): {} ms", className, methodName, stopWatch.getTotalTimeMillis());
+        }
+    }
+}

--- a/src/test/java/io/github/jhipster/sample/aop/logging/LoggingAspectTest.java
+++ b/src/test/java/io/github/jhipster/sample/aop/logging/LoggingAspectTest.java
@@ -1,0 +1,102 @@
+package io.github.jhipster.sample.aop.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.context.annotation.Import;
+import org.springframework.stereotype.Service;
+
+/**
+ * Test for verifying the functionality of the logging aspect.
+ */
+@SpringBootTest
+@EnableAspectJAutoProxy
+@Import(LoggingAspectTest.TestService.class)
+class LoggingAspectTest {
+
+    @Autowired
+    private TestService testService;
+
+    private ListAppender<ILoggingEvent> listAppender;
+    private Logger serviceLogger;
+
+    @BeforeEach
+    void setUp() {
+        // Set up logger capturing
+        LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+        serviceLogger = loggerContext.getLogger(TestService.class);
+
+        // Set to debug to capture all logs
+        serviceLogger.setLevel(Level.DEBUG);
+
+        // Create and start a list appender to capture logs
+        listAppender = new ListAppender<>();
+        listAppender.setContext(loggerContext);
+        listAppender.start();
+
+        // Add the appender to the logger
+        serviceLogger.addAppender(listAppender);
+    }
+
+    @AfterEach
+    void tearDown() {
+        // Remove appender after test
+        serviceLogger.detachAppender(listAppender);
+    }
+
+    @Test
+    void testMethodLogging() {
+        testService.testMethod();
+
+        // Get captured logs
+        List<ILoggingEvent> logsList = listAppender.list;
+
+        // Verify that the method execution was logged at DEBUG level
+        assertThat(logsList)
+            .isNotEmpty()
+            .anyMatch(
+                event ->
+                    event.getLevel() == Level.DEBUG &&
+                    event.getFormattedMessage().matches(".*Execution time of TestService.testMethod\\(\\): \\d+ ms.*")
+            );
+    }
+
+    /**
+     * Test service that will be intercepted by the logging aspect.
+     */
+    @Service
+    public static class TestService {
+
+        /**
+         * Fast method that executes quickly.
+         */
+        public String testMethod() {
+            return "This method is fast";
+        }
+
+        /**
+         * Slow method that simulates a long-running operation.
+         */
+        public String slowMethod() {
+            try {
+                // Sleep for 150ms to trigger the slow method warning
+                Thread.sleep(150);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return "This method is slow";
+        }
+    }
+}


### PR DESCRIPTION
Create a Spring AOP aspect to non-invasively log the execution time of methods in the service or repository layers, helping to identify performance bottlenecks. Execution time log should have DEBUG level and has the following format: Execution time of {class name}.{method name}(): {execution time} ms

FAIL_TO_PASS: io.github.jhipster.sample.aop.logging.LoggingAspectTest